### PR TITLE
fix unit test suite being overwrited

### DIFF
--- a/junit.go
+++ b/junit.go
@@ -126,7 +126,7 @@ func (report *JUnitTestSuites) AddSingleResult(itemType string, err error, name 
 			Name:      itemType,
 			TestCases: []JUnitTestCase{testCase},
 		}
-		report.Suites = []JUnitTestSuite{suite}
+		report.Suites = append(report.Suites, suite)
 	} else {
 		suite.Tests++
 		if failure != nil {


### PR DESCRIPTION
Fix a small bug, the report suite slice was being overwrited over and over