### PR TITLE
Workaround

### DIFF
--- a/acquisition.go
+++ b/acquisition.go
@@ -49,6 +49,7 @@ func (tp *TestParsers) LaunchAcquisition() ([]types.Event, error) {
 			},
 			Crowdsec: &csconfig.CrowdsecServiceCfg{
 				AcquisitionFilePath: tp.LocalConfig.targetDir + "/" + tp.LocalConfig.AcquisitionFile,
+				AcquisitionFiles:    []string{tp.LocalConfig.targetDir + "/" + tp.LocalConfig.AcquisitionFile},
 			},
 		}
 		log.Infof("starting acquisition")
@@ -70,6 +71,7 @@ func (tp *TestParsers) LaunchAcquisition() ([]types.Event, error) {
 			wg.Done()
 		}()
 
+		log.Printf("dataSrc: %+v", dataSrc)
 		go acquisition.StartAcquisition(dataSrc, inputLineChan, acquisTomb)
 		log.Printf("waiting for acquis tomb to die")
 

--- a/buckets.go
+++ b/buckets.go
@@ -43,6 +43,9 @@ func newBuckets(index map[string]map[string]cwhub.Item, local ConfigTest) []stri
 	)
 	for _, itemType := range []string{cwhub.SCENARIOS} {
 		for _, hubParserName := range local.Configurations[itemType] {
+			if _, ok := index[itemType][hubParserName]; !ok {
+				log.Fatalf("Item %s doesn't exist. Do you have an updated .index.json ?", hubParserName)
+			}
 			files = append(files, index[itemType][hubParserName].RemotePath)
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -237,11 +237,13 @@ func doTest(flags *Flags, targetFile string, report *JUnitTestSuites) (map[strin
 	}
 
 	log.Printf("Acquisition file : %s", target_dir+"/acquis.yaml")
-
+	cConfig.Crowdsec.AcquisitionDirPath = "./data" // ugly workaround to avoid an error check in pkg/csconfig/config.go
+	// any directory without yaml will do
 	err = cConfig.LoadConfiguration()
 	if err != nil {
 		log.Fatalf("Failed to load configuration : %s", err)
 	}
+	cConfig.Crowdsec.AcquisitionFiles = nil //ugly workaround to avoid an error check in pkg/csconfig/config.go
 
 	err = exprhelpers.Init()
 	if err != nil {


### PR DESCRIPTION
* workaround (the ugly way) the new acquisition path or dir feature
* fix the silently failing scenario when .index.json is not updated